### PR TITLE
Bug6

### DIFF
--- a/media-block-player-master/JS/BlockEditor/BlockEditor.js
+++ b/media-block-player-master/JS/BlockEditor/BlockEditor.js
@@ -205,11 +205,10 @@ class BlockEditor {
     //
     splitSelectedBlock(text1, text2){
         this.scriptFileEdited = true;
-		var block = this.blocks[this.currentBlockIndex]; //bug 6
+        var time2 = this.blocks[this.currentBlockIndex].getTime();
         this.blocks.splice(this.currentBlockIndex, 1);
         this.blocks.splice(this.currentBlockIndex, 0, new Block(text1));
-        this.blocks.splice(this.currentBlockIndex+1, 0, new Block(text2)); //bug 6 block.getTime() ??? pokazi sa audio
-
+        this.blocks.splice(this.currentBlockIndex+1, 0, new Block(text2, time2));
     }
 
     mergeSelectedBlockWithNextBlock(){

--- a/media-block-player-master/JS/ViewControllers/syncFileEditViewController.js
+++ b/media-block-player-master/JS/ViewControllers/syncFileEditViewController.js
@@ -328,7 +328,12 @@ Buttons [<-] and [->] allow you to move to any text block. However be aware that
         this.playPauseIcon.text('play_circle_outline');
         
         if (this.time2 != "0.00"){ //ak chce v procese
-            this.syncFileEditorData.playInterval(this.time1, this.time2);
+            if(this.time1 == null){
+                alert("You need to set time of previous block.");
+            }
+            else{
+                this.syncFileEditorData.playInterval(this.time1, this.time2);
+            }
 		}else{ //nastaveny blok
             this.syncFileEditorData.playSelectedBlock();
 		}

--- a/media-block-player-master/JS/syncFileEditorData.js
+++ b/media-block-player-master/JS/syncFileEditorData.js
@@ -72,11 +72,6 @@ class SyncFileEditorData {
 				time1 = "0";
 				time2 = this.blocksEditor.getTimeOfSelectedBlock();
 			}
-			else if (this.blocksEditor.getCurrentBlockIndex() == this.blocksEditor.blocks.length){
-				time1 = this.blocksEditor.getTimeOfPreviousBlock();
-				time2 = this.blocksEditor.getTimeOfSelectedBlock(); // TO DO aky cas ked je na poslednom bloku
-				
-			}
 			else{
 				time1 = this.blocksEditor.getTimeOfPreviousBlock();
 				time2 = this.blocksEditor.getTimeOfSelectedBlock();


### PR DESCRIPTION
Split fix, nepridával druhému novo vzniknutému bloku čas.
Replay fix, po splitnutí predošlý block nemá nastavený čas, ak dá používateľ replay hodí mu to alert aby si nastavil predošlý block. Predíde sa tak zúfalstvu používateľa prečo mu nejde prehrať nastavený block.

Vymazal som pár mŕtvych riadkov.